### PR TITLE
fix: Adds status endpoint + Fix Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+dprint.json
+.gitignore
+README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Release
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags-ignore:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+  release:
+    types:
+      - released
+      - prereleased
+jobs:
+  binary_linux_amd64:
+    runs-on: ubuntu-22.04
+    steps:
+         - uses: actions/checkout@v4
+         - name: Install Cargo Deps And Build LC Tracking Service
+           shell: bash
+           run: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            source "$HOME/.cargo/env"
+            sudo apt-get update && sudo apt-get install -y protobuf-compiler pkg-config
+            cargo build --release
+            mv target/release/avail-light-tracking-service target/release/avail-light-tracking-service-linux-amd64
+            pushd target/release/
+            tar czf avail-light-tracking-service-linux-amd64.tar.gz avail-light-tracking-service-linux-amd64
+            popd
+         - uses: actions/upload-artifact@v4
+           with:
+             name: avail-light-tracking-service-linux-amd64-binary
+             path: target/release/avail-light-tracking-service-linux-amd64.tar.gz
+
+  binary_publish:
+    needs: [binary_linux_amd64]
+    runs-on: ubuntu-22.04
+    steps:
+         - uses: actions/download-artifact@v4
+           with:
+             name: bridge-api-linux-amd64-binary
+         - name: Export Tag Var
+           id: prepare
+           run: |
+               TAG=${GITHUB_REF#refs/tags/}
+               echo ::set-output name=tag_name::${TAG}
+         - name: Publish Binaries
+           uses: svenstaro/upload-release-action@v2
+           with:
+             repo_token: ${{ secrets.PAT_TOKEN }}
+             file: /home/runner/work/avail-light-tracking-service/avail-light-tracking-service/avail-light-tracking-service*
+             release_name: ${{ steps.prepare.outputs.tag_name }}
+             tag: ${{ steps.prepare.outputs.tag_name }}
+             overwrite: true
+             file_glob: true
+
+  docker_build_push:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Export Tag Var
+        id: prepare
+        run: |
+            TAG=${GITHUB_REF#refs/tags/}
+            echo ::set-output name=tag_name::${TAG}
+      - name: Login to Dockerhub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push images
+        uses: docker/build-push-action@v5
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: availj/avail-light-tracking-service:${{ steps.prepare.outputs.tag_name }}
+          build-args: |
+            BUILD_PROFILE=release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,22 @@
 FROM rust:1.86-slim AS builder
 
 WORKDIR /usr/src/avail-tracker
-
-# Install dependencies required for building
 RUN apt-get update && \
-    apt-get install -y pkg-config libssl-dev git build-essential \
+    apt-get install -y pkg-config libssl-dev build-essential \
     libclang-dev llvm-dev clang && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/availproject/avail-light-tracking-service .
+COPY . .
 
 RUN cargo build --release
 
-# Runtime stage
-FROM debian:stable-slim
+FROM debian:stable-slim AS runner
+WORKDIR /avail-tracker
+ENV SERVER_ADDR="0.0.0.0"
+ENV SERVER_PORT="8989"
+ENV DB_PATH="/avail-tracker/data"
+ENV VERBOSITY="debug"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -22,33 +24,20 @@ RUN apt-get update && \
     ca-certificates \
     curl && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN groupadd -r avail && useradd -r -g avail -m -d /home/avail avail
-
-WORKDIR /avail-tracker
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd -r avail && \
+    useradd -r -g avail -m -d /home/avail avail && \
+    mkdir -p /avail-tracker/data && \
+    chown -R avail:avail /avail-tracker
 
 COPY --from=builder /usr/src/avail-tracker/target/release/avail-light-tracking-service /avail-tracker/
 
-RUN mkdir -p /avail-tracker/data && \
-    chown -R avail:avail /avail-tracker
-
-ENV SERVER_ADDR="0.0.0.0"
-ENV SERVER_PORT="8989"
-ENV DB_PATH="/avail-tracker/data"
-ENV VERBOSITY="debug"
-
 USER avail
-
 EXPOSE ${SERVER_PORT}
-
 VOLUME ["/avail-tracker/data"]
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -f http://${SERVER_ADDR}:${SERVER_PORT}/ || exit 1
+    CMD curl -f http://${SERVER_ADDR}:${SERVER_PORT}/status || exit 1
 
-ENTRYPOINT ["/bin/sh", "-c", "/avail-tracker/avail-light-tracking-service \
-    --server-addr ${SERVER_ADDR} \
-    --server-port ${SERVER_PORT} \
-    --db-path ${DB_PATH} \
-    --verbosity ${VERBOSITY}"]
+ENTRYPOINT ["/bin/sh", "-c"]
+CMD ["/avail-tracker/avail-light-tracking-service", "--server-addr ${SERVER_ADDR}", "--server-port ${SERVER_PORT}", "--db-path ${DB_PATH}", "--verbosity ${VERBOSITY}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM rust:1.86-slim AS builder
+ARG BUILD_PROFILE=release
 
 WORKDIR /usr/src/avail-tracker
 RUN apt-get update && \
@@ -9,7 +10,7 @@ RUN apt-get update && \
 
 COPY . .
 
-RUN cargo build --release
+RUN cargo build --$BUILD_PROFILE
 
 FROM debian:stable-slim AS runner
 WORKDIR /avail-tracker

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,6 +1,7 @@
 use crate::{error::ApiError, storage::RocksStorage, types::SignedPingMessage};
 use actix_web::{web, HttpResponse};
 use chrono::Utc;
+use serde_json::json;
 use signature_verifier::verify_sr25519_signature;
 use tracing::{error, info, trace};
 
@@ -49,4 +50,8 @@ pub async fn handle_client_info(
         Some(client_info) => Ok(HttpResponse::Ok().json(client_info)),
         None => Ok(HttpResponse::NotFound().json("No data found for this peer")),
     }
+}
+
+pub async fn status() -> Result<HttpResponse, ApiError> {
+    return Ok(HttpResponse::Ok().json(json!({"message": "Server is up and running!"})));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ async fn main() -> Result<()> {
                 "/client-info/{public_key}",
                 web::get().to(handlers::handle_client_info),
             )
+            .route("/status", web::get().to(handlers::status))
     })
     .bind(format!("{}:{}", opts.server_addr, opts.server_port))?
     .run()


### PR DESCRIPTION
# Changes
- [x] Adds status endpoint for better health checks
- [x] Fix health check on Dockerfile
- [x] Optimize docker image size and prune unused libs
- [x] Adds CI release workflow

# Reason for change
Current build fails on health check due to no midleware handler on root path. That leads to 404 responses and fails the checks.


Container status:
```
─$ docker ps
CONTAINER ID   IMAGE                      COMMAND                  CREATED         STATUS                     PORTS                                         NAMES
8583d945b437   availj/lc-tracker:v0.0.1   "/bin/sh -c /avail-t…"   5 minutes ago   Up 5 minutes (unhealthy)   0.0.0.0:8989->8989/tcp, [::]:8989->8989/tcp   avail-tracker
```
